### PR TITLE
Add config and mode parameters to enableSerial() call

### DIFF
--- a/src/CoogleIOT.cpp
+++ b/src/CoogleIOT.cpp
@@ -1153,7 +1153,39 @@ CoogleIOT& CoogleIOT::enableSerial(int baud)
     if(!Serial) {
 
       Serial.begin(baud);
-  
+
+      while(!Serial) {
+          yield();
+      }
+
+    }
+
+    _serial = true;
+    return *this;
+}
+
+CoogleIOT& CoogleIOT::enableSerial(int baud, SerialConfig config)
+{
+    if(!Serial) {
+
+      Serial.begin(baud, config);
+
+      while(!Serial) {
+          yield();
+      }
+
+    }
+
+    _serial = true;
+    return *this;
+}
+
+CoogleIOT& CoogleIOT::enableSerial(int baud, SerialConfig config, SerialMode mode)
+{
+    if(!Serial) {
+
+      Serial.begin(baud, config, mode);
+
       while(!Serial) {
           yield();
       }

--- a/src/CoogleIOT.h
+++ b/src/CoogleIOT.h
@@ -75,6 +75,8 @@ class CoogleIOT
         ~CoogleIOT();
         void loop();
         bool initialize();
+        CoogleIOT& enableSerial(int, SerialConfig, SerialMode);
+        CoogleIOT& enableSerial(int, SerialConfig);
         CoogleIOT& enableSerial(int);
         CoogleIOT& enableSerial();
         PubSubClient* getMQTTClient();


### PR DESCRIPTION
Since the 8266 has so few IO pins, it is quite common to use the RX pin for IO. To do so it is a good idea to initialize the UART using:

    Serial.begin(115200, SERIAL_8N1, SERIAL_TX_ONLY);

But iot->enableSerial() didn't support that. This adds those two optional params.